### PR TITLE
Create a flag_set out of an integral value

### DIFF
--- a/include/type_safe/flag_set.hpp
+++ b/include/type_safe/flag_set.hpp
@@ -427,7 +427,7 @@ public:
     static constexpr flag_set from_int(T intVal)
     {
         static_assert(std::is_unsigned<T>::value
-                          && sizeof(T) * CHAR_BIT >= flag_set_traits<Enum>::size(),
+                          && sizeof(T) <= sizeof(int_type),
                       "invalid integer type, lossy conversion");
         return flag_set(intVal);
     }

--- a/include/type_safe/flag_set.hpp
+++ b/include/type_safe/flag_set.hpp
@@ -115,6 +115,11 @@ namespace detail
             return flag_set_impl(int_type(0));
         }
 
+        static constexpr flag_set_impl from_int(int_type intVal)
+        {
+            return flag_set_impl(int_type(intVal));
+        }
+
         explicit constexpr flag_set_impl(const Enum& e) : bits_(mask(e)) {}
         template <typename Tag2>
         explicit constexpr flag_set_impl(const flag_set_impl<Enum, Tag2>& other)
@@ -416,6 +421,17 @@ class flag_set
     static_assert(flag_set_traits<Enum>::value, "invalid enum for flag_set");
 
 public:
+    /// \returns a flag_set based on the given integer value.
+    /// \requires `T` must be an unsigned integer type with number of bits <= internal used bit size.
+    template <typename T>
+    static constexpr flag_set from_int(T intVal)
+    {
+        static_assert(std::is_unsigned<T>::value
+                          && sizeof(T) * CHAR_BIT >= flag_set_traits<Enum>::size(),
+                      "invalid integer type, lossy conversion");
+        return flag_set(intVal);
+    }
+
     //=== constructors/assignment ===//
     /// \effects Creates a set where all flags are set to `0`.
     /// \group ctor_null
@@ -609,6 +625,10 @@ public:
     }
 
 private:
+    using int_type = typename detail::flag_set_impl<Enum>::int_type;
+    explicit constexpr flag_set(int_type rawvalue) noexcept : flags_(detail::flag_set_impl<Enum>::from_int(rawvalue))
+    {}
+
     detail::flag_set_impl<Enum> flags_;
 
     friend detail::get_flag_set_impl;

--- a/test/flag_set.cpp
+++ b/test/flag_set.cpp
@@ -153,6 +153,23 @@ TEST_CASE("flag_set")
         b = test_flags::c;
         check_set(b, false, false, true);
     }
+    SECTION("from_int")
+    {
+        set a = set::from_int<std::uint8_t>(0b000);
+        check_set(a, false, false, false);
+
+        a = set::from_int<std::uint8_t>(0b001);
+        check_set(a, true, false, false);
+
+        a = set::from_int<std::uint8_t>(0b010);
+        check_set(a, false, true, false);
+
+        a = set::from_int<std::uint8_t>(0b100);
+        check_set(a, false, false, true);
+
+        a = set::from_int<std::uint8_t>(0b111);
+        check_set(a, true, true, true);
+    }
     SECTION("set")
     {
         s.set(test_flags::a);


### PR DESCRIPTION
I extended the flag_set template class by a static method which allows to create the flag_set out of an integral value.

This is helpful for e.g. if you read the flags from a device via serial communication.

e.g. 

```
uint8_t readErrorFromDevice();

enum class ErrorBits
{
    ERROR_BIT_0,
    ERROR_BIT_1,
    ERROR_BIT_2,
    ERROR_BIT_3,
    _flag_set_size,
};

using ErrorStatus = type_safe::flag_set<ErrorBits>;

ErrorStatus status = ErrorStatus::from_int(readErrorFromDevice())
```
